### PR TITLE
Minor bug fixes

### DIFF
--- a/src/cards/game_structs.rs
+++ b/src/cards/game_structs.rs
@@ -44,7 +44,7 @@ impl Card{
     }
 
     pub fn get_sprite_name(&self)->&str{
-        &self.img_file
+        &self.img_file.trim()
     }
 
     pub fn get_lists(&self)->Zip<std::slice::Iter<'_, i32>, std::slice::Iter<'_, i32>>{
@@ -256,7 +256,7 @@ impl Battler{ //HAND and DECK created as INTRINSIC VALUES
     }
 
     pub fn select_hand(&self,index:usize)->Option<u32>{
-        if self.hand.len()>0{
+        if self.hand.len()>0 && index < self.hand.len(){
             Some(self.hand[index])
         }else{
             None


### PR DESCRIPTION
get_sprite_name() now trims, was getting crash because of a \r carriage return being eaten up from library file. Game was trying to read (for example) "assets/cards/Defend_Shroud.png\r" causing panic

hotfixed select_hand() so that it wouldn't crash when clicking the space to the immediate right of the furthest right card. Needs more work later